### PR TITLE
feat: support pasted barcode images

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Some of the key features of the application include:
 
 - Scan barcodes from web camera
 - Scan barcodes from image files
+- Scan barcodes from pasted clipboard images
 - Copy detected barcode to clipboard
 - Share detected barcode via Web Share API (mobile)
 - Offer option to open detected barcode in a new tab if it is a URL

--- a/src/index.html
+++ b/src/index.html
@@ -183,7 +183,7 @@
               </g>
             </svg>
 
-            Click or drop an image to scan
+            Click, paste, or drop an image to scan
           </span>
         </files-dropzone>
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -313,6 +313,45 @@ import './components/bs-history.js';
   }
 
   /**
+   * Returns the first accepted image file from the clipboard.
+   *
+   * @param {ClipboardEvent} evt - The event object.
+   * @returns {File | undefined} - The image file from the clipboard.
+   */
+  function getClipboardImageFile(evt) {
+    const files = [
+      ...Array.from(evt.clipboardData?.files || []),
+      ...Array.from(evt.clipboardData?.items || [])
+        .filter(item => item.kind === 'file')
+        .map(item => item.getAsFile())
+    ];
+
+    return files.find(file => file && ACCEPTED_MIME_TYPES.includes(file.type));
+  }
+
+  /**
+   * Handles pasted clipboard images on the image scanner tab.
+   *
+   * @param {ClipboardEvent} evt - The event object.
+   */
+  function handleDocumentPaste(evt) {
+    const fileTabSelected = tabGroupEl.querySelector('#fileTab').hasAttribute('selected');
+
+    if (!fileTabSelected) {
+      return;
+    }
+
+    const file = getClipboardImageFile(evt);
+
+    if (!file) {
+      return;
+    }
+
+    evt.preventDefault();
+    handleFileSelect(file);
+  }
+
+  /**
    * Handles the resize event on the video-capture element.
    * It is responsible for resizing the scan frame based on the video element.
    */
@@ -601,6 +640,7 @@ import './components/bs-history.js';
   playVideoButton.addEventListener('click', handlePlayVideo);
   document.addEventListener('visibilitychange', handleDocumentVisibilityChange);
   document.addEventListener('keydown', handleDocumentKeyDown);
+  document.addEventListener('paste', handleDocumentPaste);
   document.addEventListener('bs-history-success', handleHistorySuccess);
   document.addEventListener('bs-history-error', handleHistoryError);
 })();


### PR DESCRIPTION
## Summary

- make it possible to paste barcode images since it's easier than saving as file then re-uploading on PC
- this PR used AI assistance (gpt 5.5 high)

## Testing

<img width="2268" height="1326" alt="image" src="https://github.com/user-attachments/assets/7cc0a21f-6e39-4c33-a85c-a444b67a2fff" />
1. generated 'hello world' string as QR template
<img width="2268" height="1326" alt="image" src="https://github.com/user-attachments/assets/b39b9b2b-389e-4ec3-a7e4-597a9c8efaa1" />
2. choose image
<img width="2268" height="1326" alt="image" src="https://github.com/user-attachments/assets/7816dcbf-48ff-4c6b-9496-ef1bb536cbae" />
3. confirmed it gets read normally